### PR TITLE
Remove output for when no changes are detected

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -59569,8 +59569,6 @@ function addCadenceInsights(added, changed, closed, metadata) {
 async function outputDiff({ added, removed, changed, closed }, metadata) {
     const hasChanges = added.length + removed.length + changed.length + closed.length > 0;
     if (!hasChanges) {
-        core.summary.addRaw('\n## No Changes\n\nNo changes were detected in the project.');
-        await writeSummary();
         return cleanMessage(core.summary.stringify());
     }
     // Add cadence insights at the top

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -151,10 +151,6 @@ async function outputDiff({ added, removed, changed, closed }, metadata?: any) {
     added.length + removed.length + changed.length + closed.length > 0;
 
   if (!hasChanges) {
-    summary.addRaw(
-      '\n## No Changes\n\nNo changes were detected in the project.'
-    );
-    await writeSummary();
     return cleanMessage(summary.stringify());
   }
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -311,10 +311,8 @@ describe('Integration Tests', () => {
       const { run } = await import('../src/index.js');
       await run();
 
-      // Verify no changes message
-      expect(mockSummary.addRaw).toHaveBeenCalledWith(
-        '\n## No Changes\n\nNo changes were detected in the project.'
-      );
+      // Verify no output for no changes
+      expect(mockSummary.addRaw).not.toHaveBeenCalled();
     });
   });
 
@@ -340,9 +338,7 @@ describe('Integration Tests', () => {
       const { run } = await import('../src/index.js');
       await run();
 
-      expect(mockSummary.addRaw).toHaveBeenCalledWith(
-        '\n## No Changes\n\nNo changes were detected in the project.'
-      );
+      expect(mockSummary.addRaw).not.toHaveBeenCalled();
     });
 
     it('should handle large number of changes', async () => {

--- a/tests/summary.test.ts
+++ b/tests/summary.test.ts
@@ -41,14 +41,12 @@ describe('summary', () => {
   });
 
   describe('outputDiff', () => {
-    it('should show no changes message when no changes', async () => {
+    it('should produce no output when no changes', async () => {
       const diff = { added: [], removed: [], changed: [], closed: [] };
 
       const result = await summary.default.outputDiff(diff);
 
-      expect(mockSummary.addRaw).toHaveBeenCalledWith(
-        '\n## No Changes\n\nNo changes were detected in the project.'
-      );
+      expect(mockSummary.addRaw).not.toHaveBeenCalled();
       expect(result).toBe('test summary');
     });
 


### PR DESCRIPTION
## Summary
- Removes "No changes were detected in the project." output when there are no changes
- Updates tests to expect no output instead of the "no changes" message
- Provides cleaner output for automated workflows

## Test plan
- [x] Modified existing tests to verify no output is produced when there are no changes
- [x] Built and verified the distribution includes the changes
- [x] Confirmed the "No changes" message is completely removed from the codebase

🤖 Generated with [Claude Code](https://claude.ai/code)